### PR TITLE
Fix memory corruption caused by dwSize override

### DIFF
--- a/ddraw/glDirectDraw.cpp
+++ b/ddraw/glDirectDraw.cpp
@@ -874,6 +874,7 @@ HRESULT EnumDisplayModes2(DWORD dwFlags, LPDDSURFACEDESC2 lpDDSurfaceDesc, LPVOI
 	ZeroMemory(&ddmode,sizeof(DDSURFACEDESC2));
 	ddmode.dwSize = sizeof(DDSURFACEDESC2);
 	ddmode.dwFlags = DDSD_HEIGHT | DDSD_WIDTH | DDSD_PITCH | DDSD_PIXELFORMAT | DDSD_REFRESHRATE;
+	ddmode.ddpfPixelFormat.dwSize = sizeof(DDPIXELFORMAT);
 	if (!_isnan(dxglcfg.postsizex) && !_isnan(dxglcfg.postsizey) &&
 		(dxglcfg.postsizex > 0.25f) && (dxglcfg.postsizey > 0.25f) &&
 		(dxglcfg.postsizex != 1.0f) && (dxglcfg.postsizey != 1.0f) &&
@@ -1663,6 +1664,7 @@ HRESULT WINAPI glDirectDraw7::GetDisplayMode(LPDDSURFACEDESC2 lpDDSurfaceDesc2)
 	ZeroMemory(&ddsdMode, sizeof(DDSURFACEDESC2));
 	ddsdMode.dwSize = sizeof(DDSURFACEDESC2);
 	ddsdMode.dwFlags = DDSD_REFRESHRATE | DDSD_PIXELFORMAT | DDSD_PITCH | DDSD_WIDTH | DDSD_HEIGHT;
+	ddsdMode.ddpfPixelFormat.dwSize = sizeof(DDPIXELFORMAT);
 	ddsdMode.ddpfPixelFormat.dwFlags = DDPF_RGB;
 	DEVMODE currmode;
 	ZeroMemory(&currmode,sizeof(DEVMODE));

--- a/ddraw/glDirectDraw.cpp
+++ b/ddraw/glDirectDraw.cpp
@@ -1704,7 +1704,7 @@ HRESULT WINAPI glDirectDraw7::GetDisplayMode(LPDDSURFACEDESC2 lpDDSurfaceDesc2)
 		if(lpDDSurfaceDesc2->dwSize < sizeof(DDSURFACEDESC)) ERR(DDERR_INVALIDPARAMS);
 		if(lpDDSurfaceDesc2->dwSize > sizeof(DDSURFACEDESC2))
 			lpDDSurfaceDesc2->dwSize = sizeof(DDSURFACEDESC2);
-		memcpy(lpDDSurfaceDesc2,&ddsdMode,lpDDSurfaceDesc2->dwSize);
+		memcpy(&lpDDSurfaceDesc2->dwSize+1,&ddsdMode.dwSize+1,lpDDSurfaceDesc2->dwSize-sizeof(DWORD)); // copy skipping first DWORD dwSize
 		TRACE_EXIT(23,DD_OK);
 		return DD_OK;
 	}
@@ -1745,7 +1745,7 @@ HRESULT WINAPI glDirectDraw7::GetDisplayMode(LPDDSURFACEDESC2 lpDDSurfaceDesc2)
 	if(lpDDSurfaceDesc2->dwSize < sizeof(DDSURFACEDESC)) TRACE_RET(HRESULT,23,DDERR_INVALIDPARAMS);
 	if(lpDDSurfaceDesc2->dwSize > sizeof(DDSURFACEDESC2))
 		lpDDSurfaceDesc2->dwSize = sizeof(DDSURFACEDESC2);
-	memcpy(lpDDSurfaceDesc2,&ddsdMode,lpDDSurfaceDesc2->dwSize);
+	memcpy(&lpDDSurfaceDesc2->dwSize+1,&ddsdMode.dwSize+1,lpDDSurfaceDesc2->dwSize-sizeof(DWORD)); // copy skipping first DWORD dwSize
 	TRACE_EXIT(23,DD_OK);
 	return DD_OK;
 }

--- a/ddraw/glDirectDrawSurface.cpp
+++ b/ddraw/glDirectDrawSurface.cpp
@@ -293,7 +293,16 @@ glDirectDrawSurface7::glDirectDrawSurface7(LPDIRECTDRAW7 lpDD7, LPDDSURFACEDESC2
 		texture = parenttex;
 		glTexture_AddRef(texture);
 	}
-	else glTexture_Create(&ddsd, &texture, ddInterface->renderer, fakex, fakey, hasstencil, FALSE, 0);
+	else
+	{
+		*error = glTexture_Create(&ddsd, &texture, ddInterface->renderer, fakex, fakey, hasstencil, FALSE, 0);
+		if (*error != DD_OK)
+		{
+			TRACE_VAR("*error",23,*error);
+			TRACE_EXIT(-1,0);
+			return;
+		}
+	}
 	if (!(ddsd.dwFlags & DDSD_PITCH))
 	{
 		ddsd.dwFlags |= DDSD_PITCH;

--- a/ddraw/glDirectDrawSurface.cpp
+++ b/ddraw/glDirectDrawSurface.cpp
@@ -1331,7 +1331,7 @@ HRESULT WINAPI glDirectDrawSurface7::GetSurfaceDesc(LPDDSURFACEDESC2 lpDDSurface
 	TRACE_ENTER(2,14,this,14,lpDDSurfaceDesc);
 	if(!this) TRACE_RET(HRESULT,23,DDERR_INVALIDOBJECT);
 	if(!lpDDSurfaceDesc) TRACE_RET(HRESULT,23,DDERR_INVALIDPARAMS);
-	memcpy(lpDDSurfaceDesc,&ddsd,lpDDSurfaceDesc->dwSize);
+	memcpy(&lpDDSurfaceDesc->dwSize+1,&ddsd.dwSize+1,lpDDSurfaceDesc->dwSize-sizeof(DWORD)); // copy skipping first DWORD dwSize
 	TRACE_EXIT(23,DD_OK);
 	return DD_OK;
 }
@@ -1354,6 +1354,7 @@ HRESULT WINAPI glDirectDrawSurface7::Lock(LPRECT lpDestRect, LPDDSURFACEDESC2 lp
 {
 	TRACE_ENTER(5,14,this,26,lpDestRect,14,lpDDSurfaceDesc,9,dwFlags,14,hEvent);
 	if(!this) TRACE_RET(HRESULT,23,DDERR_INVALIDOBJECT);
+	if(lpDDSurfaceDesc->dwSize != sizeof(DDSURFACEDESC2)) TRACE_RET(HRESULT,23,DDERR_INVALIDPARAMS);
 	if(locked) TRACE_RET(HRESULT,23,DDERR_SURFACEBUSY);
 	HRESULT error = glTexture_Lock(this->texture, this->miplevel, lpDestRect, lpDDSurfaceDesc, dwFlags, FALSE);
 	if (SUCCEEDED(error))
@@ -2333,9 +2334,11 @@ HRESULT WINAPI glDirectDrawSurface1::Lock(LPRECT lpDestRect, LPDDSURFACEDESC lpD
 {
 	TRACE_ENTER(5,14,this,26,lpDestRect,14,lpDDSurfaceDesc,9,dwFlags,14,hEvent);
 	if(!this) TRACE_RET(HRESULT,23,DDERR_INVALIDOBJECT);
+	if (lpDDSurfaceDesc->dwSize != sizeof(DDSURFACEDESC)) TRACE_RET(HRESULT, 23, DDERR_INVALIDPARAMS);
 	DDSURFACEDESC2 ddsd;
 	ZeroMemory(&ddsd, sizeof(DDSURFACEDESC2));
 	memcpy(&ddsd, lpDDSurfaceDesc, sizeof(DDSURFACEDESC));
+	ddsd.dwSize = sizeof(DDSURFACEDESC2);
 	HRESULT ret = glDDS7->Lock(lpDestRect, &ddsd, dwFlags, hEvent);
 	if (ret != DD_OK) TRACE_RET(HRESULT, 23, ret);
 	ddsd.dwSize = sizeof(DDSURFACEDESC);
@@ -2638,9 +2641,11 @@ HRESULT WINAPI glDirectDrawSurface2::Lock(LPRECT lpDestRect, LPDDSURFACEDESC lpD
 {
 	TRACE_ENTER(5,14,this,26,lpDestRect,14,lpDDSurfaceDesc,9,dwFlags,14,hEvent);
 	if(!this) TRACE_RET(HRESULT,23,DDERR_INVALIDOBJECT);
+	if(lpDDSurfaceDesc->dwSize != sizeof(DDSURFACEDESC)) TRACE_RET(HRESULT,23,DDERR_INVALIDPARAMS);
 	DDSURFACEDESC2 ddsd;
 	ZeroMemory(&ddsd, sizeof(DDSURFACEDESC2));
 	memcpy(&ddsd, lpDDSurfaceDesc, sizeof(DDSURFACEDESC));
+	ddsd.dwSize = sizeof(DDSURFACEDESC2);
 	HRESULT ret = glDDS7->Lock(lpDestRect, &ddsd, dwFlags, hEvent);
 	if (ret != DD_OK) TRACE_RET(HRESULT, 23, ret);
 	ddsd.dwSize = sizeof(DDSURFACEDESC);
@@ -2968,9 +2973,11 @@ HRESULT WINAPI glDirectDrawSurface3::Lock(LPRECT lpDestRect, LPDDSURFACEDESC lpD
 {
 	TRACE_ENTER(5,14,this,26,lpDestRect,14,lpDDSurfaceDesc,9,dwFlags,14,hEvent);
 	if(!this) TRACE_RET(HRESULT,23,DDERR_INVALIDOBJECT);
+	if(lpDDSurfaceDesc->dwSize != sizeof(DDSURFACEDESC)) TRACE_RET(HRESULT,23,DDERR_INVALIDPARAMS);
 	DDSURFACEDESC2 ddsd;
 	ZeroMemory(&ddsd, sizeof(DDSURFACEDESC2));
 	memcpy(&ddsd, lpDDSurfaceDesc, sizeof(DDSURFACEDESC));
+	ddsd.dwSize = sizeof(DDSURFACEDESC2);
 	HRESULT ret = glDDS7->Lock(lpDestRect, &ddsd, dwFlags, hEvent);
 	if (ret != DD_OK) TRACE_RET(HRESULT, 23, ret);
 	ddsd.dwSize = sizeof(DDSURFACEDESC);

--- a/ddraw/glRenderWindow.cpp
+++ b/ddraw/glRenderWindow.cpp
@@ -79,7 +79,7 @@ DWORD glRenderWindow::_Entry()
 	if (!wndclasscreated)
 	{
 		wndclass.cbSize = sizeof(WNDCLASSEXA);
-		wndclass.style = 0;
+		wndclass.style = CS_DBLCLKS;
 		wndclass.lpfnWndProc = RenderWndProc;
 		wndclass.cbClsExtra = 0;
 		wndclass.cbWndExtra = 0;


### PR DESCRIPTION
It's normal to use same struct twice and more times. Game that I tried to run with DXGL was crashing after few common API calls. From other hand it works fine with standard ddraw. The value of EIP at crash out loudly tells us that crash is caused by stack corruption. So I verified those few API calls and it turns out that GetDisplayMode was overriding dwSize with value bigger than it was set, and then GetSurfaceDesc was filling DDSURFACEDESC according to the new dwSize causing stack corruption.

First, I made hot fix, and it worked. Then, I made little test: https://gist.github.com/realmonster/0af97e2d1e040182b7751558469f409e

And after fixing all issues it show, new version for some reason even fixed more bugs in the game. I have no idea where they come from but after making this test pass without issues, the game under DXGL I test works with it even better than before fix.