### PR TITLE
Update compiler detection to Visual C++ 2022 Update 3.

### DIFF
--- a/Installer/dxgl.nsi
+++ b/Installer/dxgl.nsi
@@ -48,7 +48,7 @@ SetCompressor /SOLID lzma
 !define PRODUCT_UNINST_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}"
 !define PRODUCT_UNINST_ROOT_KEY "HKLM"
 
-!if ${COMPILER} == "VC2022_2"
+!if ${COMPILER} == "VC2022_3"
 !ifdef _DEBUG
 !define PLUGINDIR "Debug VS2022"
 !ifdef _CPU_X64
@@ -180,7 +180,7 @@ SetCompressor /SOLID lzma
 !define runtime_regkey SOFTWARE\Microsoft\DevDiv\vc\Servicing\12.0\RuntimeMinimum
 !define runtime_regvalue Install
 !define PRODUCT_SUFFIX "-msvc12"
-!else if ${COMPILER} == "VC2022_2"
+!else if ${COMPILER} == "VC2022_3"
 !define download_runtime 1
 !define runtime_url http://dxgl.org/download/runtimes/vc14.32.31332/VC_redist.x64.exe
 !define runtime_name "Visual C++ 2022.2 x64"
@@ -231,7 +231,7 @@ SetCompressor /SOLID lzma
 !define runtime_regkey SOFTWARE\Microsoft\DevDiv\vc\Servicing\12.0\RuntimeMinimum
 !define runtime_regvalue Install
 !define PRODUCT_SUFFIX "-msvc12"
-!else if ${COMPILER} == "VC2022_2"
+!else if ${COMPILER} == "VC2022_3"
 !define download_runtime 1
 !define runtime_url http://dxgl.org/download/runtimes/vc14.32.31332/VC_redist.x86.exe
 !define runtime_name "Visual C++ 2022.2 x86"
@@ -406,7 +406,7 @@ Function .onInit
 	Quit
   ${EndIf}
   !endif
-  !if ${COMPILER} == "VC2022_2"
+  !if ${COMPILER} == "VC2022_3"
   dxgl-nsis::CheckSSE2 $0
   Pop $0
   ${If} $0 == "0"
@@ -476,7 +476,7 @@ Function .onInit
   !ifdef _CPU_X64
   SetRegView 32
   !endif
-  !if ${COMPILER} == "VC2022_2"
+  !if ${COMPILER} == "VC2022_3"
   StrCmp $0 1 skipvcredist1
   goto vcinstall
   skipvcredist1:
@@ -603,7 +603,7 @@ Section Uninstall
 SectionEnd
 
 !if ${SIGNTOOL} == 1
-!if ${COMPILER} == "VC2022_2"
+!if ${COMPILER} == "VC2022_3"
 !finalize 'signtool sign /tr http://timestamp.sectigo.com /td sha384 /fd sha384 /as %1'
 !endif
 !endif

--- a/buildtool/buildtool.c
+++ b/buildtool/buildtool.c
@@ -521,14 +521,13 @@ int ProcessHeaders(char *path)
 			strncpy(findptr, "\"VC2010\"\n", 13);
 			#elif (_MSC_VER == 1800)
 			strncpy(findptr, "\"VC2013\"\n", 13);
-			//#elif (_MSC_VER == 1932) FIXME:  Check at next MSVC update
-			#elif ((_MSC_VER == 1931) || (_MSC_VER == 1932)) // Shim to bypass VS bug, means VS 2022.1 works too
-			strncpy(findptr, "\"VC2022_2\"\n", 13);
-			#elif ((_MSC_VER >= 1930) && (_MSC_VER < 1932))
-			#error Please update your Visual Studio 2022 to Update 2 before continuing.  If you have an expired MSDN subscription and cannot update your paid version of Visual Studio, you can still use the Community version to compile DXGL.
-			#elif (_MSC_VER > 1932)
-			#pragma message ("Detected a newer version of Visual Studio, compiling assuming 2022.2.")
-			strncpy(findptr, "\"VC2022_2\"\n", 13);
+			#elif (_MSC_VER == 1933)
+			strncpy(findptr, "\"VC2022_3\"\n", 13);
+			#elif ((_MSC_VER >= 1930) && (_MSC_VER < 1933))
+			#error Please update your Visual Studio 2022 to Update 3 before continuing.  If you have an expired MSDN subscription and cannot update your paid version of Visual Studio, you can still use the Community version to compile DXGL.
+			#elif (_MSC_VER > 1933)
+			#pragma message ("Detected a newer version of Visual Studio, compiling assuming 2022.3.")
+			strncpy(findptr, "\"VC2022_3\"\n", 13);
 			#else
 			strncpy(findptr, "\"UNKNOWN\"\n", 13);
 			#endif


### PR DESCRIPTION
Redistributable wasn't updated in VS2022.3 so remains unchanged.