### PR TITLE
0.5.x

### DIFF
--- a/Installer/dxgl.nsi
+++ b/Installer/dxgl.nsi
@@ -26,7 +26,8 @@ SetCompressor /SOLID lzma
 
 !include 'WinVer.nsh'
 !include 'LogicLib.nsh'
-!include "WordFunc.nsh"
+!include 'WordFunc.nsh'
+!include 'Sections.nsh'
 !include 'x64.nsh'
 !include "..\common\version.nsh"
 
@@ -649,6 +650,14 @@ Function .onInit
   ${If} $0 == "0"
     SectionSetFlags ${SEC_WINEDLLOVERRIDE} 0
 	SectionSetText ${SEC_WINEDLLOVERRIDE} ""
+  ${Else}
+    ${VersionConvert} "$0" "" $R0
+	${VersionConvert} "11.6" "" $R1
+	${VersionCompare} "$R0" "$R1" $R2
+	${If} $R2 == 0
+	${OrIf} $R2 == 1
+	  !insertmacro UnselectSection ${SEC_WINEDLLOVERRIDE}
+	${EndIf}
   ${EndIf}
 FunctionEnd
 

--- a/cfgmgr/ReadMe.txt
+++ b/cfgmgr/ReadMe.txt
@@ -168,6 +168,16 @@ Valid settings:
 1 - Prefer dark mode
 2 - Prefer light mode
 
+Member WindowCorner
+INI Entry WindowCorner
+INI Group display
+Sets the window corner preference in Windows 11 and above.
+Valid settings:
+0 - System default
+1 - Use square corners
+2 - Use rounded corners
+3 - Use small rounded corners
+
 Member scalingfilter
 INI Entry ScalingFilter
 INI Group scaling

--- a/dxgl-example.ini
+++ b/dxgl-example.ini
@@ -224,6 +224,15 @@ UseSetDisplayConfig=false
 ; 1 - Prefer dark mode
 ; 2 - Prefer light mode
 
+; WindowCorner - Integer
+; Overrides the window corner style in Windows 11 (v21H2) and above.
+; Default is 0
+; The following values are valid:
+; 0 - Allow the system to choose the appropriate rounding
+; 1 - Force square corners
+; 2 - Force rounded corners
+; 3 - Force small rounded corners
+
 [scaling]
 ; ScalingFilter - Integer
 ; Selects the filter to be used to scale the output image

--- a/dxgl-nsis/dxgl-nsis.c
+++ b/dxgl-nsis/dxgl-nsis.c
@@ -124,6 +124,8 @@ void __declspec(dllexport) IsWine(HWND hwndParent, int string_size,
 	HMODULE ntdll;
 	char* (__cdecl *wine_get_version)();
 	char out[256];
+	int i;
+	char *winever;
 	EXDLL_INIT();
 	ntdll = LoadLibraryA("ntdll.dll");
 	if (!ntdll)
@@ -134,10 +136,22 @@ void __declspec(dllexport) IsWine(HWND hwndParent, int string_size,
 		return;
 	}
 	wine_get_version = (char*(__cdecl*)())GetProcAddress(ntdll, "wine_get_version");
-	if (wine_get_version) out[0] = '1';
-	else out[0] = '0';
+	if (wine_get_version)
+	{
+		winever = wine_get_version();
+		for (i = 0; i < 255; i++)
+		{
+			out[i] = winever[i];
+			if (winever[i] == 0) break;
+		}
+		out[255] = 0;
+	}
+	else
+	{
+		out[0] = '0';
+		out[1] = out[2] = out[3] = 0;
+	}
 	FreeLibrary(ntdll);
-	out[1] = out[2] = out[3] = 0;
 	pushstring(out);
 }
 


### PR DESCRIPTION
Add corner rounding option to cfgmgr readme and example INI file.
Make Wine DLL overrides disabled by default in Wine 11.6 and up, as Wine 11.6 has added native support for DirectX wrappers.